### PR TITLE
Improve timeout handling in `receive_response()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,7 +1463,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shvcall"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "async-channel 2.3.1",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvcall"
-version = "3.8.0"
+version = "3.8.1"
 edition = "2024"
 
 [[bin]]


### PR DESCRIPTION
 - use `futures::pending()` instead of `u64:::MAX` for no timeout
 - remove unnecessary subtraction of `time_left`